### PR TITLE
Transaction Management Imrovements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Future ideas:
 - User options to enable/disable/remap as they like.
 - Chrome Extension Store? (maybe)
 
+## A Note for Vimium users
+Many MoneyMover keyboard shortcuts are inspired by [Vim](https://www.vim.org/) and keyboard navigation fanatics may also have the [Vimium - The Hacker's Browser](https://vimium.github.io/) installed as well.
+
+MoneyMover overrides some of the default shortcuts for Vimium, so if you have both plugins installed please add ":https://my.lunchmoney.app/" to the list of Excluded URLs on the Vimium Plugin Options page.
+
 ## Table of Contents
 
 - [Setup](#setup)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "autoprefixer": "^10.4.0",
+    "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.8.1",
     "glob": "^7.1.6",

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -1,4 +1,8 @@
 import { getElementsForKey } from "@utils/getElementForKey";
+import { 
+  resetTransactionKeyboardSelection, 
+  restoreTransactionKeyboardSelection 
+} from "@utils/getElementForKey";
 import { initializeMessageListener } from "@messages/init";
 import { Sequencer } from "@utils/Sequencer";
 import "@styles/keyboard-shortcuts.css"
@@ -118,7 +122,10 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
       }
       case "Enter": {
         const EnterButton = getElementsForKey("Enter");
-        EnterButton?.click();
+        if (EnterButton instanceof HTMLButtonElement) {
+          //else don't click as active row was re-selected
+          EnterButton?.click();
+        }
         break;
       }
       case "Escape": {
@@ -146,4 +153,83 @@ export const keyDownEventListener = (seq: ReturnType<typeof Sequencer>) =>
 
 const sequencer = Sequencer();
 document.addEventListener("keydown", keyDownEventListener(sequencer));
+
+// Going through hoops here to update the Keyboard Shortcuts selected
+// Transaction whenever the Transaction Table is re-rendered
+
+// Mutation Observer will restore the keyboard selection after re-render
+const mutationCallback = (mutationsList: MutationRecord[]) => {
+  for (const mutation of mutationsList) {
+    if ((mutation.type === 'childList') || (mutation.type === 'attributes')) {
+      const target = mutation.target;
+      if (target.nodeType === Node.ELEMENT_NODE) { 
+        const targetElement = target as Element; 
+        // If a transaction just got updated, restore the last active Keyboard Selection
+        if (targetElement.classList.contains('transaction-row') && 
+          (targetElement.classList.contains('cleared') || targetElement.classList.contains('uncleared')) && 
+          !targetElement.classList.contains('keyboardSelected')) {
+          restoreTransactionKeyboardSelection();
+        }
+      }
+    }
+  }
+};
+
+let observer = new MutationObserver(mutationCallback);
+let transactionTable: HTMLElement | null
+const config = { attributes: true, childList: true, subtree: true};
+
+// Function to enable the mutation monitor when Transaction Table is detectedd
+function monitorTransactionTable() {
+  // Called when the transactions page is loaded or updated.
+  // Since it can take time for the transactions table to load,
+  // wait for a bit and then if it is found monitor it for changes so that 
+  // the keyboard selected transaction persists across changes
+  setTimeout(() => {
+    transactionTable = document.querySelector('.p-transactions-table');
+    if (transactionTable) {
+      console.log("[MoneyMover] Keyboard Shortcuts enabled for transaction table.")
+      //transactionTable = document.getElementById('.p-transactions-table');
+      observer.observe(transactionTable, config);
+    } else {
+      console.log("[MoneyMover] Couldn't find transaction table for Keyboard Shortcuts.")
+    }
+  }, 3000); // Adjust the delay as needed
+}
+
+
+// Check for Transaction Table on an initial page load
+window.addEventListener('load', () => {
+  // Check if the transaction page is being loaded and set up a listener
+  // to monitor changes in the Transaction table
+  const currentUrl = window.location.href;  
+  if (currentUrl.includes("transactions")) {
+    onTransPage = true;
+    monitorTransactionTable()
+  } else {
+    onTransPage = false;
+  }
+});
+
+// Unfortunately, the only way I was able to consistently check for the
+// presence of the transaction table was to periodically check the current URL
+// when a lunchmoney tab is active
+let lastUrl = location.href; 
+let onTransPage = false;
+setInterval(() => {
+  const currentUrl = location.href;
+  if (currentUrl !== lastUrl) {
+    lastUrl = currentUrl; 
+    if (!onTransPage && currentUrl.includes("transactions")) {
+      onTransPage = true;
+      monitorTransactionTable()
+    } else if (onTransPage && (!currentUrl.includes("transactions"))) {
+      console.log("[Money Mover]Disconnecting Transactions Table monitor")
+      onTransPage = false;
+      resetTransactionKeyboardSelection()
+      observer.disconnect()
+    }
+  }
+}, 1000); // Check every 1000 milliseconds (1 second) - yes it's kludgy...
+
 console.log("🪄 MoneyMover intialized.");

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -41,20 +41,24 @@ function clickElement(key: string) {
 
 const keybindings = [
   {
-    key: "n",
+    key: ">",
     description: "Go to the 'Next' month",
   },
   {
-    key: "p",
+    key: "<",
     description: "Go to the 'Previous' month",
   },
   {
-    key: "r",
-    description: "Click 'Review Transactions' button",
+    key: ".",
+    description: "Go to 'this' month",
   },
   {
-    key: "t",
-    description: "Go to 'this' month",
+    key: "j",
+    description: "Move down a row in a table",
+  },
+  {
+    key: "k",
+    description: "Move up a row in a table",
   },
   {
     key: "/",
@@ -82,6 +86,77 @@ const keybindings = [
   },
 ];
 
+const transactionKeybindings = [
+  {
+    key: "x",
+    description: "Select transaction for bulk edit",
+  },
+  {
+    key: "c",
+    description: "Change 'Category'",
+  },
+  {
+    key: "p",
+    description: "Change 'Payee'",
+  },
+  {
+    key: "a",
+    description: "Change 'Amount'",
+  },
+  {
+    key: "n",
+    description: "Change 'Notes'",
+  },
+  {
+    key: "t",
+    description: "Add Tag",
+  },
+  {
+    key: "r",
+    description: "Mark/Unmark current transaction reviewed",
+  },
+  {
+    key: "m",
+    description: "Mark selected transactions reviewed",
+  },
+  {
+    key: "Enter",
+    description: "Open details pane for selected transaction",
+  },
+  {
+    key: "/",
+    description: "Quick Filter",
+  },
+]
+
+const recurringKeybindings = [
+  {
+    key: "Enter",
+    description: "Open details pane for current row",
+  },
+  {
+    key: "n",
+    description:
+      "This key is 'Overloaded' meaning it works differently depending on the UI state",
+    overloads: [
+      {
+        description: "'No' button if Create rule dialog box is open.",
+      },
+      {
+        description: "'This is not a recurring item' if details pane is open."
+      },
+    ],    
+  },
+  {
+    key: "y",
+    description: "'Yes' button if Create rule dialog box is open.",
+  },
+  {
+    key: "a",
+    description: "'Approve this new recurring item' if details pane is open",
+  },
+]
+
 const Popup = () => {
   return (
     <div className={"w-[575px] rounded-md shadow-md p-8 text-md"}>
@@ -99,7 +174,7 @@ const Popup = () => {
       </div>
 
       <div className="my-8">
-        <p className={"font-semibold text-2xl mb-4"}>Key Bindings:</p>
+        <p className={"font-semibold text-2xl mb-4"}>Global Key Bindings:</p>
         <ul className={"ml-4 list-disc"}>
           {keybindings.map((binding, i) => (
             <li
@@ -136,6 +211,79 @@ const Popup = () => {
           ))}
         </ul>
       </div>
+
+      <div className="my-8">
+        <p className={"font-semibold text-2xl mb-4"}>Transactions Page:</p>
+        <ul className={"ml-4 list-disc"}>
+          {transactionKeybindings.map((binding, i) => (
+            <li
+              className={"hover:cursor-help"}
+              key={i}
+              onMouseEnter={() => {
+                highlightElement(binding.key);
+              }}
+              onMouseLeave={() => {
+                unhighlightElement(binding.key);
+              }}
+              onClick={() => {
+                clickElement(binding.key);
+              }}
+            >
+              <div className={"mb-2"}>
+                <span
+                  className={
+                    "font-semibold p-1 bg-gray-100 rounded-md border border-stone-200 min-w-[20px] inline-flex justify-center"
+                  }
+                >
+                  {binding.key}
+                </span>
+                <span className={"ml-3"}>{binding.description}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="my-8">
+        <p className={"font-semibold text-2xl mb-4"}>Recurring Page:</p>
+        <ul className={"ml-4 list-disc"}>
+          {recurringKeybindings.map((binding, i) => (
+            <li
+              className={"hover:cursor-help"}
+              key={i}
+              onMouseEnter={() => {
+                highlightElement(binding.key);
+              }}
+              onMouseLeave={() => {
+                unhighlightElement(binding.key);
+              }}
+              onClick={() => {
+                clickElement(binding.key);
+              }}
+            >
+              <div className={"mb-2"}>
+                <span
+                  className={
+                    "font-semibold p-1 bg-gray-100 rounded-md border border-stone-200 min-w-[20px] inline-flex justify-center"
+                  }
+                >
+                  {binding.key}
+                </span>
+                <span className={"ml-3"}>{binding.description}</span>
+              </div>
+              {binding.overloads && (
+                <ul className={"ml-4 list-disc"}>
+                  {binding.overloads.map((overload, i) => (
+                    <li key={i}>{overload.description}</li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+
       <p className={"mt-4"}>
         At this point, all the keybindings are loosely based on Google
         Calendar's navigation keys. These keys should only trigger if the user

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -3,6 +3,8 @@ const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const srcDir = path.join(__dirname, "..", "src");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+
 
 module.exports = {
   entry: {
@@ -62,6 +64,7 @@ module.exports = {
       options: {},
     }),
     new webpack.HotModuleReplacementPlugin(),
+    new CleanWebpackPlugin(),
   ],
   devServer: {
     hot: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,6 +749,14 @@
   resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.29.tgz#a48795ecadf957f6c0d10e0c34af86c098fa5bee"
   integrity sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==
 
+"@types/glob@^7.1.1":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -819,6 +827,11 @@
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.4.tgz#a4ed836e069491414bab92c31fdea9e557aca0d9"
   integrity sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw==
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node-forge@^1.3.0":
   version "1.3.8"
@@ -1303,10 +1316,22 @@ array-flatten@^2.1.2:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  integrity sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==
+  dependencies:
+    array-uniq "^1.0.1"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+  integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1594,6 +1619,13 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+clean-webpack-plugin@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-4.0.0.tgz#72947d4403d452f38ed61a9ff0ada8122aacd729"
+  integrity sha512-WuWE1nyTNAyW5T7oNyys2EN0cfP2fdRxhxnIQWiAp0bMabPdHhoGxM8A6YL2GhqwgrPnnaemVE7nv5XJ2Fhh2w==
+  dependencies:
+    del "^4.1.1"
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -1880,6 +1912,19 @@ define-lazy-prop@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
+del@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
+  integrity sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    globby "^6.1.0"
+    is-path-cwd "^2.0.0"
+    is-path-in-cwd "^2.0.0"
+    p-map "^2.0.0"
+    pify "^4.0.1"
+    rimraf "^2.6.3"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2388,7 +2433,7 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -2416,6 +2461,17 @@ globby@^11.0.3:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
+
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  integrity sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -2708,6 +2764,25 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-path-cwd@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
+  integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
+
+is-path-in-cwd@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz#bfe2dca26c69f397265a4009963602935a053acb"
+  integrity sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==
+  dependencies:
+    is-path-inside "^2.1.0"
+
+is-path-inside@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2"
+  integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
+  dependencies:
+    path-is-inside "^1.0.2"
 
 is-plain-obj@^3.0.0:
   version "3.0.0"
@@ -3685,6 +3760,11 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
+p-map@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
 p-retry@^4.5.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
@@ -3735,6 +3815,11 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
+path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==
+
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
@@ -3765,10 +3850,27 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pify@^2.3.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
+
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  integrity sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+  integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
 
 pirates@^4.0.1:
   version "4.0.6"
@@ -4105,6 +4207,13 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^3.0.0, rimraf@^3.0.2, "rimraf@^3.0.2 ":
   version "3.0.2"


### PR DESCRIPTION
A couple of changes to make the keyboard shortcuts more useful for managing transactions:
* Ensure that the currently selected transaction is not scrolled off the screen
  * This turned out to be easy, just a call to `row.Row.scrollIntoView({ behavior: 'smooth', block: 'center' })` whenever the selection is updated.
* Keep the keyboard selection active after editing a transaction so you don't need to scroll from the top again 
  * This was not as easy and involved setting up a Mutation Observer for the transaction table.   The real problem was determining WHEN to enable this observer.  The only way I could tell when to do this is to periodically poll for the current URL and invoke the logic when /transactions are active.   I'd be happy to get input on better ways to do this!

I also made a few other changes that hung me up when I first tried to use this plugin:
* Updated the popup help with new shortcuts this version of the plugin has
* Added a note about conflicts with the Vimium chrome plugin in the readme